### PR TITLE
feat: crud de client disponivel versao beta

### DIFF
--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ClientController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ClientController.java
@@ -1,26 +1,74 @@
 package br.com.luizalabsserverrest.controller;
 
 import br.com.luizalabsserverrest.model.entity.ClientEntity;
-import br.com.luizalabsserverrest.repository.ClientRepository;
+import br.com.luizalabsserverrest.service.GenericService;
 import br.com.luizalabsserverrest.util.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping(path = Constants.ROUTE_CLIENT)
 public class ClientController {
 
     @Autowired
-    private ClientRepository repository;
+    private GenericService<ClientEntity> service;
 
     @GetMapping
-    public List<ClientEntity> findAll() {
+    public List<?> findAll() {
 
-        return repository.findAll();
+        return service.findAll();
+    }
+
+    @GetMapping(path = Constants.ROUTE_ID)
+    public ResponseEntity<?> findById(@PathVariable("id") Long id) {
+
+        Optional<ClientEntity> client = service.findById(id);
+
+        if(!client.isPresent()) {
+
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(client.get());
+    }
+
+    @PostMapping(path = Constants.ROUTE_SAVE)
+    public ClientEntity create(@RequestBody ClientEntity client) {
+        return service.save(client);
+    }
+
+    @PutMapping(path = Constants.ROUTE_ID)
+    public ResponseEntity<ClientEntity> update(@PathVariable("id") Long id, @RequestBody ClientEntity newClient) {
+
+        Optional<ClientEntity> client = service.findById(id);
+
+        if(!client.isPresent()) {
+
+            return ResponseEntity.notFound().build();
+        }
+
+        ClientEntity clientSave = client.get();
+        clientSave.setEmail(newClient.getEmail());
+        clientSave.setName(newClient.getName());
+
+        return ResponseEntity.ok(service.save(clientSave));
+    }
+
+    @DeleteMapping(path = Constants.ROUTE_ID)
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
+
+        if(!service.existsById(id)) {
+
+            return ResponseEntity.notFound().build();
+        }
+
+        service.deleteById(id);
+
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/model/entity/ClientEntity.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/model/entity/ClientEntity.java
@@ -1,13 +1,11 @@
 package br.com.luizalabsserverrest.model.entity;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+@NoArgsConstructor
 @Entity
-@Getter
-@Setter
 @Table(name = "client")
 public class ClientEntity {
     @Id
@@ -21,4 +19,27 @@ public class ClientEntity {
     @Column(name = "cli_email")
     private String email;
 
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
 }

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/GenericService.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/GenericService.java
@@ -1,0 +1,17 @@
+package br.com.luizalabsserverrest.service;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GenericService<T> {
+
+    List<T> findAll();
+
+    Optional<T> findById(Long id);
+
+    boolean existsById(Long id);
+
+    T save(T type);
+
+    void deleteById(Long id);
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/impl/ClientServiceImpl.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/impl/ClientServiceImpl.java
@@ -1,0 +1,42 @@
+package br.com.luizalabsserverrest.service.impl;
+
+import br.com.luizalabsserverrest.model.entity.ClientEntity;
+import br.com.luizalabsserverrest.repository.ClientRepository;
+import br.com.luizalabsserverrest.service.GenericService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ClientServiceImpl implements GenericService<ClientEntity> {
+
+    @Autowired
+    private ClientRepository clientRepository;
+
+    @Override
+    public List<ClientEntity> findAll() {
+        return clientRepository.findAll();
+    }
+
+    @Override
+    public Optional<ClientEntity> findById(Long id) {
+        return clientRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return clientRepository.existsById(id);
+    }
+
+    @Override
+    public ClientEntity save(ClientEntity type) {
+        return clientRepository.save(type);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        clientRepository.deleteById(id);
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/util/Constants.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/util/Constants.java
@@ -4,6 +4,10 @@ public class Constants {
 
     // =================== ROUTES API ==================== //
 
+    /* GENERAL */
+    public final static String ROUTE_ID = "/{id}";
+    public final static String ROUTE_SAVE = "/save";
+
     /* CLIENT */
     public final static String ROUTE_CLIENT = "/api/v1/client";
 


### PR DESCRIPTION
   - Foi implementado as rotas de crud da entidade "client".
   - Foi criado mais um pacote (service), que mapea apenas as repository
     de cada entidade, deixando apenas os possiveis metodos a serem
     utilizados, e ainda, é um lugar para colocar regra de manipulação das
     informações processadas (caso seja necessário).