### PR TITLE
feat: adicionando o spring security + nova tabela "account"

### DIFF
--- a/luizalabs-server-rest/pom.xml
+++ b/luizalabs-server-rest/pom.xml
@@ -61,6 +61,25 @@
 			<version>2.9.2</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
+			<version>5.3.3.RELEASE</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/config/SwaggerConfig.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/config/SwaggerConfig.java
@@ -6,19 +6,39 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig extends WebMvcConfigurationSupport {
 
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder().securityReferences(defaultAuth()).build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("JWT", authorizationScopes));
+    }
+
     @Bean
     public Docket greetingApi() {
         return new Docket(DocumentationType.SWAGGER_2)
+                .securityContexts(Arrays.asList(securityContext()))
+                .securitySchemes(Arrays.asList(apiKey()))
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("br.com.luizalabsserverrest"))
                 .build()

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/AccountController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/AccountController.java
@@ -1,0 +1,54 @@
+package br.com.luizalabsserverrest.controller;
+
+import br.com.luizalabsserverrest.controller.request.AccountRequest;
+import br.com.luizalabsserverrest.controller.response.AccountResponse;
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import br.com.luizalabsserverrest.service.GenericService;
+import br.com.luizalabsserverrest.util.Constants;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@Api(value = "Account")
+@RequestMapping(path = Constants.ROUTE_ACCOUNT)
+public class AccountController {
+
+    @Autowired
+    private GenericService<AccountEntity> service;
+
+    @ApiOperation(value = "Salva as informações de uma nova conta")
+    @ApiResponses(value = {
+            @ApiResponse(code = HttpServletResponse.SC_OK, message = "ok", response = AccountResponse.class),
+            @ApiResponse(code = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message = "An unexpected error occurred") })
+    @PostMapping(path = Constants.ROUTE_SAVE)
+    public AccountResponse create(@RequestBody AccountRequest accountRequest) {
+
+        AccountEntity accountEntity = AccountRequest.convertToEntity(accountRequest);
+
+        return AccountResponse.convertToResponse(service.save(accountEntity));
+
+    }
+
+    @ApiOperation(value = "Deleta as informações de uma conta")
+    @ApiResponse(code = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message = "An unexpected error occurred")
+    @DeleteMapping(path = Constants.ROUTE_ID)
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
+
+        if(!service.existsById(id)) {
+
+            return ResponseEntity.notFound().build();
+        }
+
+        service.deleteById(id);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/AuthController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/AuthController.java
@@ -1,0 +1,63 @@
+package br.com.luizalabsserverrest.controller;
+
+import br.com.luizalabsserverrest.controller.request.AccountRequest;
+import br.com.luizalabsserverrest.controller.response.AuthResponse;
+import br.com.luizalabsserverrest.controller.response.MessageResponse;
+import br.com.luizalabsserverrest.security.JwtTokenUtil;
+import br.com.luizalabsserverrest.service.JwtUserDetailsService;
+import br.com.luizalabsserverrest.util.Constants;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@Api(value = "Auth")
+@CrossOrigin
+public class AuthController {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private JwtUserDetailsService userDetailsService;
+
+    @ApiOperation(value = "Faz login na API")
+    @ApiResponses(value = {
+            @ApiResponse(code = HttpServletResponse.SC_OK, message = "ok", response = AuthResponse.class),
+            @ApiResponse(code = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message = "An unexpected error occurred") })
+    @PostMapping(Constants.ROUTE_SIGN_IN)
+    public ResponseEntity<?> signIn(@RequestBody AccountRequest accountRequest) throws Exception {
+
+        try {
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(accountRequest.getUsername(),accountRequest.getPassword()));
+        } catch (DisabledException e) {
+            return ResponseEntity.badRequest().body(new MessageResponse("Usuário desabilitado."));
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.badRequest().body(new MessageResponse("Usuário ou senha inválidos."));
+        }
+
+        final UserDetails userDetails = userDetailsService.loadUserByUsername(accountRequest.getUsername());
+
+        final String token = jwtTokenUtil.generateToken(userDetails);
+
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+}
+

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ClientController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ClientController.java
@@ -105,7 +105,7 @@ public class ClientController {
             @ApiResponse(code = HttpServletResponse.SC_OK, message = "ok", response = ClientResponse.class),
             @ApiResponse(code = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message = "An unexpected error occurred") })
     @PostMapping(path = Constants.ROUTE_ADD_FAVORITE_PRODUCTS_BY_CLIENT)
-    public ResponseEntity<ClientResponse> updateFavoriteProductsByClientId(@RequestBody FavoriteProductsRequest fpRequest) {
+    public ResponseEntity<ClientResponse> addFavoriteProductsToClient(@RequestBody FavoriteProductsRequest fpRequest) {
 
         Optional<ClientEntity> client = service.findById(fpRequest.getClientId());
 
@@ -116,7 +116,7 @@ public class ClientController {
 
         ClientEntity clientSave = client.get();
 
-        List<ProductEntity> productEntityList = productService.findAllById(fpRequest.getProductsIds());
+        List<ProductEntity> productEntityList = productService.findAllById(fpRequest.getFavoriteProductsIds());
 
         clientSave.setFavoriteProductsList(productEntityList);
 

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ProductController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ProductController.java
@@ -7,7 +7,6 @@ import br.com.luizalabsserverrest.model.entity.ProductEntity;
 import br.com.luizalabsserverrest.repository.ProductRepository;
 import br.com.luizalabsserverrest.service.GenericService;
 import br.com.luizalabsserverrest.util.Constants;
-import ch.qos.logback.core.net.server.Client;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 @RestController
 @Api(value = "Product")

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/request/AccountRequest.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/request/AccountRequest.java
@@ -1,0 +1,37 @@
+package br.com.luizalabsserverrest.controller.request;
+
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class AccountRequest {
+
+    private String username;
+    private String password;
+
+    public static AccountEntity convertToEntity(AccountRequest accountRequest)
+    {
+        AccountEntity accountEntity = new AccountEntity();
+        accountEntity.setUsername(accountRequest.getUsername());
+        accountEntity.setPassword(accountRequest.getPassword());
+
+        return accountEntity;
+
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/request/ClientRequest.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/request/ClientRequest.java
@@ -1,11 +1,6 @@
 package br.com.luizalabsserverrest.controller.request;
 
 import br.com.luizalabsserverrest.model.entity.ClientEntity;
-import br.com.luizalabsserverrest.model.entity.ProductEntity;
-import br.com.luizalabsserverrest.service.GenericService;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ClientRequest {
 

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/request/FavoriteProductsRequest.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/request/FavoriteProductsRequest.java
@@ -1,11 +1,10 @@
 package br.com.luizalabsserverrest.controller.request;
-
 import java.util.Set;
 
 public class FavoriteProductsRequest {
 
     private Long clientId;
-    private Set<Long> productsIds;
+    private Set<Long> favoriteProductsIds;
 
     public Long getClientId() {
         return clientId;
@@ -15,11 +14,11 @@ public class FavoriteProductsRequest {
         this.clientId = clientId;
     }
 
-    public Set<Long> getProductsIds() {
-        return productsIds;
+    public Set<Long> getFavoriteProductsIds() {
+        return favoriteProductsIds;
     }
 
-    public void setProductsIds(Set<Long> productsIds) {
-        this.productsIds = productsIds;
+    public void setFavoriteProductsIds(Set<Long> favoriteProductsIds) {
+        this.favoriteProductsIds = favoriteProductsIds;
     }
 }

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/response/AccountResponse.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/response/AccountResponse.java
@@ -1,0 +1,41 @@
+package br.com.luizalabsserverrest.controller.response;
+
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import br.com.luizalabsserverrest.model.entity.ClientEntity;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+public class AccountResponse {
+
+    private Long id;
+    private String username;
+
+    public static AccountResponse convertToResponse(AccountEntity accountEntity)
+    {
+        AccountResponse accountResponse = new AccountResponse();
+        accountResponse.setId(accountEntity.getId());
+        accountResponse.setUsername(accountEntity.getUsername());
+
+        return accountResponse;
+
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/response/AuthResponse.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/response/AuthResponse.java
@@ -1,0 +1,18 @@
+package br.com.luizalabsserverrest.controller.response;
+
+import java.io.Serializable;
+
+public class AuthResponse implements Serializable {
+
+    private static final long serialVersionUID = -8091879091924046844L;
+
+    private final String jwttoken;
+
+    public AuthResponse(String jwttoken) {
+        this.jwttoken = jwttoken;
+    }
+
+    public String getToken() {
+        return this.jwttoken;
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/response/MessageResponse.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/response/MessageResponse.java
@@ -1,0 +1,20 @@
+package br.com.luizalabsserverrest.controller.response;
+
+public class MessageResponse {
+
+    String message;
+
+    public MessageResponse(String msg)
+    {
+        this.message = msg;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/model/entity/AccountEntity.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/model/entity/AccountEntity.java
@@ -1,0 +1,46 @@
+package br.com.luizalabsserverrest.model.entity;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor
+@Entity
+@Table(name = "account")
+public class AccountEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "acc_id")
+    private Long id;
+
+    @Column(name = "acc_username")
+    private String username;
+
+    @Column(name = "acc_password")
+    private String password;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/model/entity/ClientEntity.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/model/entity/ClientEntity.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @NoArgsConstructor
 @Entity

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/repository/AccountRepository.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/repository/AccountRepository.java
@@ -1,0 +1,15 @@
+package br.com.luizalabsserverrest.repository;
+
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AccountRepository extends JpaRepository<AccountEntity, Long> {
+
+    Optional<AccountEntity> findByUsername(String username);
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/JwtAuthenticationEntryPoint.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package br.com.luizalabsserverrest.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Serializable;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint, Serializable {
+
+    private static final long serialVersionUID = -7858869558953243875L;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/JwtRequestFilter.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/JwtRequestFilter.java
@@ -1,0 +1,73 @@
+package br.com.luizalabsserverrest.security;
+
+import br.com.luizalabsserverrest.service.JwtUserDetailsService;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUserDetailsService jwtUserDetailsService;
+
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        final String requestTokenHeader = request.getHeader("Authorization");
+
+        String username = null;
+        String jwtToken = null;
+        // JWT Token is in the form "Bearer token". Remove Bearer word and get
+        // only the Token
+        if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
+            jwtToken = requestTokenHeader.substring(7);
+            try {
+                username = jwtTokenUtil.getUsernameFromToken(jwtToken);
+            } catch (IllegalArgumentException e) {
+                System.out.println("Unable to get JWT Token");
+            } catch (ExpiredJwtException e) {
+                System.out.println("JWT Token has expired");
+            }
+        } else {
+            logger.warn("JWT Token does not begin with Bearer String");
+        }
+
+        // Once we get the token validate it.
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+            UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
+
+            // if token is valid configure Spring Security to manually set
+            // authentication
+            if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                usernamePasswordAuthenticationToken
+                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                // After setting the Authentication in the context, we specify
+                // that the current user is authenticated. So it passes the
+                // Spring Security Configurations successfully.
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/JwtTokenUtil.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/JwtTokenUtil.java
@@ -1,0 +1,66 @@
+package br.com.luizalabsserverrest.security;
+
+import br.com.luizalabsserverrest.util.Constants;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtTokenUtil implements Serializable {
+
+    private static final long serialVersionUID = -2550185165626007488L;
+
+    //retrieve username from jwt token
+    public String getUsernameFromToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    //retrieve expiration date from jwt token
+    public Date getExpirationDateFromToken(String token) {
+        return getClaimFromToken(token, Claims::getExpiration);
+    }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaimsFromToken(token);
+        return claimsResolver.apply(claims);
+    }
+    //for retrieveing any information from token we will need the secret key
+    private Claims getAllClaimsFromToken(String token) {
+        return Jwts.parser().setSigningKey(Constants.KEY_JWT).parseClaimsJws(token).getBody();
+    }
+
+    //generate token for user
+    public String generateToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        return "Bearer " + doGenerateToken(claims, userDetails);
+    }
+
+    //while creating the token -
+    //1. Define  claims of the token, like Issuer, Expiration, Subject, and the ID
+    //2. Sign the JWT using the HS512 algorithm and secret key.
+    //3. According to JWS Compact Serialization(https://tools.ietf.org/html/draft-ietf-jose-json-web-signature-41#section-3.1)
+    //   compaction of the JWT to a URL-safe string
+    private String doGenerateToken(Map<String, Object> claims, UserDetails userDetails) {
+
+        return Jwts.builder().setClaims(claims)
+                .setSubject(userDetails.getUsername())
+                .claim("authorities", userDetails.getAuthorities())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                //.setExpiration(new Date(System.currentTimeMillis() + Constants.TEMPO_EXPIRACAO))
+                .signWith(SignatureAlgorithm.HS512, Constants.KEY_JWT).compact();
+    }
+
+    //validate token
+    public Boolean validateToken(String token, UserDetails userDetails) {
+        final String username = getUsernameFromToken(token);
+        return (username.equals(userDetails.getUsername()));
+    }
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/WebSecurityConfig.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/security/WebSecurityConfig.java
@@ -1,0 +1,93 @@
+package br.com.luizalabsserverrest.security;
+
+import br.com.luizalabsserverrest.util.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    @Autowired
+    private UserDetailsService jwtUserDetailsService;
+    @Autowired
+    private JwtRequestFilter jwtRequestFilter;
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        // configure AuthenticationManager so that it knows from where to load
+        // user for matching credentials
+        // Use BCryptPasswordEncoder
+        auth.userDetailsService(jwtUserDetailsService).passwordEncoder(passwordEncoder());
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/v2/api-docs", "/configuration/ui", "/swagger-resources/**", "/configuration/security", "/swagger-ui.html", "/webjars/**");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http.csrf().disable().cors().and()
+
+                .authorizeRequests()
+                .antMatchers(HttpMethod.POST, Constants.ROUTE_SIGN_IN).permitAll()
+                .antMatchers(HttpMethod.POST, Constants.ROUTE_ACCOUNT + Constants.ROUTE_SAVE).permitAll()
+                // all other requests need to be authenticated
+                .anyRequest().authenticated()
+                // store user's state.
+                .and().exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint)
+
+                .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        // Add a filter to validate the tokens with every request
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        final CorsConfiguration corsConfiguration = new CorsConfiguration();
+        final UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
+
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.addAllowedOrigin("*");
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        urlBasedCorsConfigurationSource.registerCorsConfiguration("/**", corsConfiguration);
+
+        return new CorsFilter(urlBasedCorsConfigurationSource);
+    }
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/JwtUserDetailsService.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/JwtUserDetailsService.java
@@ -1,0 +1,32 @@
+package br.com.luizalabsserverrest.service;
+
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import br.com.luizalabsserverrest.service.impl.AccountServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Service
+public class JwtUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private AccountServiceImpl accountService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<AccountEntity> accountEntity = accountService.findByUsername(username);
+        if (!accountEntity.isPresent()) {
+            throw new UsernameNotFoundException("Usuário não existe: " + username);
+        }
+
+        // third parameter is about roles, we can create here
+        return new User(accountEntity.get().getUsername(), accountEntity.get().getPassword(),new ArrayList<>());
+    }
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/impl/AccountServiceImpl.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/impl/AccountServiceImpl.java
@@ -1,0 +1,66 @@
+package br.com.luizalabsserverrest.service.impl;
+
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import br.com.luizalabsserverrest.repository.AccountRepository;
+import br.com.luizalabsserverrest.service.GenericService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Service
+public class AccountServiceImpl implements GenericService<AccountEntity> {
+
+    @Autowired
+    private AccountRepository repository;
+
+    @Override
+    public List<AccountEntity> findAll() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Page<AccountEntity> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
+
+    @Override
+    public Optional<AccountEntity> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<AccountEntity> findAllById(Iterable<Long> ids) {
+        return repository.findAllById(ids);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return repository.existsById(id);
+    }
+
+    @Override
+    public AccountEntity save(AccountEntity accountEntity) {
+
+        accountEntity.setPassword(BCrypt.hashpw(accountEntity.getPassword(), BCrypt.gensalt(10)));
+
+        return repository.save(accountEntity);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        repository.deleteById(id);
+    }
+
+    public Optional<AccountEntity> findByUsername(String username)
+    {
+        return repository.findByUsername(username);
+    }
+
+
+}

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/util/Constants.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/util/Constants.java
@@ -8,11 +8,19 @@ public class Constants {
     public final static String ROUTE_ID = "/{id}";
     public final static String ROUTE_SAVE = "/save";
 
+    /* SIGN IN */
+    public final static String ROUTE_SIGN_IN = "/api/v1/signIn";
+    /* ACCOUNT */
+    public final static String ROUTE_ACCOUNT = "/api/v1/account";
     /* CLIENT */
     public final static String ROUTE_CLIENT = "/api/v1/client";
-    public final static String ROUTE_ADD_FAVORITE_PRODUCTS_BY_CLIENT = "/products/{client_id}";
+    public final static String ROUTE_ADD_FAVORITE_PRODUCTS_BY_CLIENT = "/products";
     /* PRODUCT */
     public final static String ROUTE_PRODUCT = "/api/v1/product";
     public final static String ROUTE_FIND_FAVORITE_PRODUCTS_BY_CLIENT = "/client/{id}";
+
+    // ============= JWT ============== //
+
+    public final static String KEY_JWT = "luizalabs";
 
 }

--- a/luizalabs-server-rest/src/main/resources/db/migration/V1_init.sql
+++ b/luizalabs-server-rest/src/main/resources/db/migration/V1_init.sql
@@ -32,7 +32,7 @@ COMMENT ON COLUMN luizalabs.client.cli_email IS 'Client email';
 /* Add Primary Key */
 ALTER TABLE luizalabs.client ADD CONSTRAINT pkclient
 	PRIMARY KEY (cli_id);
-	
+
 
 /******************** Add Table: luizalabs.product ************************/
 
@@ -44,7 +44,7 @@ CREATE TABLE luizalabs.product
 	pro_image text NULL,
 	pro_brand VARCHAR(50) NULL,
 	pro_title VARCHAR(50) NULL,
-	pro_review_score real NULL 
+	pro_review_score real NULL
 );
 
 /* Add Comments */


### PR DESCRIPTION
   - Foi adicionando o spring security para controle de autenticação das
     rotas, incluindo um novo pacote no projeto "security". Esse pacote
     possui:
      - JwtAutenticationEntryPoint: classe retorna caso o token não
	esteja mais autorizado a usar a aplicação.
      - JwtRequestFilter: cada envio de tokennas requests, é captado por
	essa classe que consegue validar por exemplo se o token expirou,
	se o formato do token enviado é correto, etc...
      - JwtTokenUtil: como diz o nome, essa classe contem metodos uteis
	para trabalhar com token, como por exemplo gerar um, validar,
	etc...
      - WebSecurityConfig: atualizei a lógica de permissão das rotas,
	para apenas deixar para acesso publico as rotas de cadastro de
	contas (/account/save), de login na aplicação (/signin) e da
	view web do swagger.
   - Foi criado mamis uma tabela chamada "account"(consequentemente + 1
     entity, controller, repository...), que armazena o
     username e password do usuario cadastrado na aplicação. Isso
     permite a gente fazer o sistema de autenticação.
   - SwaggerConfig foi alterado para permitir enviar o token também pelo
     seu link web.
   - Foi feito tambem pequenas revisões de código.