### PR TITLE
test: tests basicos das controllers account e client para testar o CI

### DIFF
--- a/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/LuizalabsServerRestApplicationTests.java
+++ b/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/LuizalabsServerRestApplicationTests.java
@@ -1,13 +1,9 @@
 package br.com.luizalabsserverrest;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class LuizalabsServerRestApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
 
 }

--- a/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/AccountControllerTest.java
+++ b/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/AccountControllerTest.java
@@ -1,0 +1,93 @@
+package br.com.luizalabsserverrest.controller;
+
+import br.com.luizalabsserverrest.model.entity.AccountEntity;
+import br.com.luizalabsserverrest.security.JwtAuthenticationEntryPoint;
+import br.com.luizalabsserverrest.security.JwtTokenUtil;
+import br.com.luizalabsserverrest.service.JwtUserDetailsService;
+import br.com.luizalabsserverrest.service.impl.AccountServiceImpl;
+import br.com.luizalabsserverrest.util.Constants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import org.zalando.problem.ProblemModule;
+import org.zalando.problem.violations.ConstraintViolationProblemModule;
+
+@WebMvcTest(controllers = AccountController.class)
+@ActiveProfiles("test")
+public class AccountControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AccountServiceImpl accountService;
+
+    @MockBean
+    private JwtUserDetailsService jwtUserDetailsService;
+
+    @MockBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockBean
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+
+        objectMapper.registerModule(new ProblemModule());
+        objectMapper.registerModule(new ConstraintViolationProblemModule());
+
+    }
+
+    @Test
+    void shouldCreateNewAccount() throws Exception{
+
+        given(accountService.save(any(AccountEntity.class))).willAnswer((invocation) -> invocation.getArgument(0));
+
+        AccountEntity accountEntity = new AccountEntity();
+        accountEntity.setPassword("teste");
+        accountEntity.setUsername("teste");
+
+        this.mockMvc.perform(post(Constants.ROUTE_ACCOUNT + Constants.ROUTE_SAVE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(accountEntity)))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    void shouldDeleteAccount() throws Exception{
+
+        Long accountId = 1L;
+        AccountEntity accountEntity = new AccountEntity();
+        accountEntity.setId(accountId);
+        accountEntity.setPassword("teste");
+        accountEntity.setUsername("teste");
+
+        given(accountService.findById(accountId)).willReturn(Optional.of(accountEntity));
+
+        doNothing().when(accountService).deleteById(accountEntity.getId());
+
+        this.mockMvc.perform(delete(Constants.ROUTE_ACCOUNT + Constants.ROUTE_ID, accountEntity.getId()))
+                .andExpect(status().isOk());
+
+    }
+
+}

--- a/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/ClientControllerTest.java
+++ b/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/ClientControllerTest.java
@@ -1,0 +1,121 @@
+package br.com.luizalabsserverrest.controller;
+
+import br.com.luizalabsserverrest.controller.request.FavoriteProductsRequest;
+import br.com.luizalabsserverrest.model.entity.ClientEntity;
+import br.com.luizalabsserverrest.model.entity.ProductEntity;
+import br.com.luizalabsserverrest.security.JwtAuthenticationEntryPoint;
+import br.com.luizalabsserverrest.security.JwtTokenUtil;
+import br.com.luizalabsserverrest.service.GenericService;
+import br.com.luizalabsserverrest.service.JwtUserDetailsService;
+import br.com.luizalabsserverrest.service.impl.ClientServiceImpl;
+import br.com.luizalabsserverrest.util.Constants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zalando.problem.ProblemModule;
+import org.zalando.problem.violations.ConstraintViolationProblemModule;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ClientController.class)
+@ActiveProfiles("test")
+public class ClientControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ClientServiceImpl service;
+
+    @MockBean
+    private GenericService<ProductEntity> productEntityGenericService;
+
+    @MockBean
+    private JwtUserDetailsService jwtUserDetailsService;
+
+    @MockBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockBean
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private List<ClientEntity> list;
+
+    @BeforeEach
+    public void setup() {
+        this.list = new ArrayList<>();
+        ClientEntity entitySave = new ClientEntity();
+        entitySave.setId(1L);
+        entitySave.setEmail("teste@teste.com");
+        entitySave.setName("teste2");
+        this.list.add(entitySave);
+
+        objectMapper.registerModule(new ProblemModule());
+        objectMapper.registerModule(new ConstraintViolationProblemModule());
+
+    }
+
+    @Test
+    void shouldFetchAll() throws Exception{
+        given(service.findAll()).willReturn(list);
+
+        this.mockMvc.perform(get(Constants.ROUTE_CLIENT))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldCreateAddFavoriteProducts() throws Exception{
+
+        FavoriteProductsRequest fpRequest = new FavoriteProductsRequest();
+        Set<Long> ids = new HashSet<>();
+        ids.add(1L);
+        ids.add(2L);
+        fpRequest.setClientId(1L);
+        fpRequest.setFavoriteProductsIds(ids);
+
+        this.mockMvc.perform(post(Constants.ROUTE_CLIENT + Constants.ROUTE_ADD_FAVORITE_PRODUCTS_BY_CLIENT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(fpRequest)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldCreateNewClient() throws Exception{
+
+        given(service.save(any(ClientEntity.class))).willAnswer((invocation) -> invocation.getArgument(0));
+
+        this.mockMvc.perform(post(Constants.ROUTE_CLIENT + Constants.ROUTE_SAVE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(list.get(0))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldFetchById() throws Exception{
+
+        Long userId = 1L;
+        ClientEntity clientEntity = list.get(0);
+
+        given(service.findById(1L)).willReturn(Optional.of(clientEntity));
+
+        this.mockMvc.perform(get(Constants.ROUTE_CLIENT + Constants.ROUTE_ID, userId))
+                .andExpect(status().isOk())
+                ;
+    }
+
+}


### PR DESCRIPTION
   - Foi feito alguns testes das controllers Account e Client para
     testar a integração do sistema com o CI.
   - Foi removido o metodo da LuizalabsServerRestApplicationTests, pois
     quero deixar somente a checagem das controllers.