### PR TITLE
tests: criação de testes unitarios das controllers + refact + merge master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 env:
   global:
-    - PROJECT_VERSION=0.0.4-RELEASE
+    - PROJECT_VERSION=0.0.5-RELEASE
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1
     - CLOUDSDK_PYTHON=python2.7
 before_install:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Caso for apenas para executar a aplicação:
     - Postman:
         - Resultado: /docs/postman/LuizaLabs.postman_test_run.json
         - Descrição: no postman é possível importar esse "run" e ver os resultados dos testes de cada endpoint.
+    - Spring boot:
+        - Ao buildar o projeto com o ./mvnw clean build dentro da pasta luizalabs-server-rest, os testes unitários da API são executados (hoje o Travis-CI faz essa parte e indica o estado do commit no GitHub). Atualmente, a API tem 27 testes unitários focados nos testes das controllers (endpoints).
 
 # Tecnologias/Ferramentas
 

--- a/luizalabs-server-rest/Dockerfile
+++ b/luizalabs-server-rest/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8
-COPY target/luizalabs-server-rest-0.0.4-RELEASE.jar /app.jar
+COPY target/luizalabs-server-rest-0.0.5-RELEASE.jar /app.jar
 VOLUME /tmp
 #EXPOSE 3000/tcp
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/luizalabs-server-rest/docker-compose.yml
+++ b/luizalabs-server-rest/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   luizalabs-api:
-    image: ensleyribeiro/luizalabs-api:0.0.4-RELEASE
+    image: ensleyribeiro/luizalabs-api:0.0.5-RELEASE
     #build: .
     restart: always
     depends_on:

--- a/luizalabs-server-rest/k8s/luizalabs-api-deployment.yaml
+++ b/luizalabs-server-rest/k8s/luizalabs-api-deployment.yaml
@@ -15,7 +15,7 @@ spec:
         io.kompose.service: luizalabs-api
     spec:
       containers:
-      - image: ensleyribeiro/luizalabs-api:0.0.4-RELEASE
+      - image: ensleyribeiro/luizalabs-api:0.0.5-RELEASE
         imagePullPolicy: ""
         name: luizalabs-api
         ports:

--- a/luizalabs-server-rest/pom.xml
+++ b/luizalabs-server-rest/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>br.com</groupId>
 	<artifactId>luizalabs-server-rest</artifactId>
-	<version>0.0.4-RELEASE</version>
+	<version>0.0.5-RELEASE</version>
 	<name>luizalabs-api</name>
 	<description>API rest do desafio</description>
 

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/config/SwaggerConfig.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/config/SwaggerConfig.java
@@ -50,7 +50,7 @@ public class SwaggerConfig extends WebMvcConfigurationSupport {
         return new ApiInfoBuilder()
                 .title("Spring Boot REST API - LuizaLabs")
                 .description("\"Spring Boot REST API for LuizaLabs\"")
-                .version("0.0.4-RELEASE")
+                .version("0.0.5-RELEASE")
                 .license("Apache License Version 2.0")
                 .licenseUrl("https://www.apache.org/licenses/LICENSE-2.0\"")
                 .contact(new Contact("Ensley", "https://www.linkedin.com/in/ensley-ribeiro-37b293126/", "ensleyfmr@gmail.com"))

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ClientController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ClientController.java
@@ -118,7 +118,7 @@ public class ClientController {
 
     @ApiOperation(value = "Adiciona os produtos favoritos ao cliente")
     @ApiResponses(value = {
-            @ApiResponse(code = HttpServletResponse.SC_OK, message = "ok", response = ClientResponse.class),
+            @ApiResponse(code = HttpServletResponse.SC_OK, message = "ok"),
             @ApiResponse(code = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message = "An unexpected error occurred") })
     @PostMapping(path = Constants.ROUTE_ADD_FAVORITE_PRODUCTS_BY_CLIENT)
     public ResponseEntity<ClientResponse> addFavoriteProductsToClient(@RequestBody FavoriteProductsRequest favoriteProductsRequest) {

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ProductController.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/controller/ProductController.java
@@ -7,6 +7,7 @@ import br.com.luizalabsserverrest.model.entity.ClientEntity;
 import br.com.luizalabsserverrest.model.entity.ProductEntity;
 import br.com.luizalabsserverrest.repository.ProductRepository;
 import br.com.luizalabsserverrest.service.GenericService;
+import br.com.luizalabsserverrest.service.impl.ProductServiceImpl;
 import br.com.luizalabsserverrest.util.Constants;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,13 +27,11 @@ import java.util.Optional;
 public class ProductController {
 
     @Autowired
-    private GenericService<ProductEntity> service;
+    private ProductServiceImpl service;
 
     @Autowired
     private GenericService<ClientEntity> clientService;
 
-    @Autowired
-    private ProductRepository repository;
 
     @ApiOperation(value = "Mostra lista de produtos por página de tamanho 5, iniciando em 1")
     @ApiResponses(value = {
@@ -100,7 +99,7 @@ public class ProductController {
             return ResponseEntity.notFound().build();
         }
 
-        return ResponseEntity.ok(repository.findAndFetchClientEntityListEagerly(clientId));
+        return ResponseEntity.ok(service.findAndFetchClientEntityListEagerly(clientId));
 
     }
 

--- a/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/impl/ProductServiceImpl.java
+++ b/luizalabs-server-rest/src/main/java/br/com/luizalabsserverrest/service/impl/ProductServiceImpl.java
@@ -6,6 +6,7 @@ import br.com.luizalabsserverrest.service.GenericService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -50,5 +51,10 @@ public class ProductServiceImpl implements GenericService<ProductEntity> {
     @Override
     public void deleteById(Long id) {
         repository.deleteById(id);
+    }
+
+    public List<ProductEntity> findAndFetchClientEntityListEagerly(Long id)
+    {
+        return repository.findAndFetchClientEntityListEagerly(id);
     }
 }

--- a/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/AccountControllerTest.java
+++ b/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/AccountControllerTest.java
@@ -10,24 +10,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import org.zalando.problem.ProblemModule;
 import org.zalando.problem.violations.ConstraintViolationProblemModule;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+
+
 @WebMvcTest(controllers = AccountController.class)
-@ActiveProfiles("test")
+@AutoConfigureMockMvc(addFilters = false)
 public class AccountControllerTest {
 
     @Autowired
@@ -59,34 +60,72 @@ public class AccountControllerTest {
     @Test
     void shouldCreateNewAccount() throws Exception{
 
-        given(accountService.save(any(AccountEntity.class))).willAnswer((invocation) -> invocation.getArgument(0));
-
+        // prepare
         AccountEntity accountEntity = new AccountEntity();
-        accountEntity.setPassword("teste");
+        accountEntity.setId(1L);
         accountEntity.setUsername("teste");
+        accountEntity.setPassword("teste");
 
+        // logic
+        when(accountService.save(any(AccountEntity.class))).thenReturn(accountEntity);
+
+        // test/check
         this.mockMvc.perform(post(Constants.ROUTE_ACCOUNT + Constants.ROUTE_SAVE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(accountEntity)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is(accountEntity.getUsername())))
+                .andExpect(jsonPath("$.id", is(accountEntity.getId().intValue())));
+
+    }
+
+    @Test
+    void shouldReturn400WhenCreatingANewAccountWithAnExistingUsername() throws Exception{
+
+        // prepare
+        AccountEntity accountEntity = new AccountEntity();
+        accountEntity.setUsername("teste");
+        accountEntity.setPassword("teste");
+
+        // logic
+        when(accountService.existsByUsername(accountEntity.getUsername())).thenReturn(true);
+
+        // test/check
+        this.mockMvc.perform(post(Constants.ROUTE_ACCOUNT + Constants.ROUTE_SAVE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(accountEntity)))
+                .andExpect(status().isBadRequest());
 
     }
 
     @Test
     void shouldDeleteAccount() throws Exception{
 
+        // prepare
         Long accountId = 1L;
-        AccountEntity accountEntity = new AccountEntity();
-        accountEntity.setId(accountId);
-        accountEntity.setPassword("teste");
-        accountEntity.setUsername("teste");
 
-        given(accountService.findById(accountId)).willReturn(Optional.of(accountEntity));
+        // logic
+        when(accountService.existsById(accountId)).thenReturn(true);
+        doNothing().when(accountService).deleteById(accountId);
 
-        doNothing().when(accountService).deleteById(accountEntity.getId());
+        // test/check
+        this.mockMvc.perform(delete(Constants.ROUTE_ACCOUNT + Constants.ROUTE_ID, accountId))
+                .andExpect(status().isNoContent());
 
-        this.mockMvc.perform(delete(Constants.ROUTE_ACCOUNT + Constants.ROUTE_ID, accountEntity.getId()))
-                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturn404WhenDeletingNonExistingAccount() throws Exception{
+
+        // prepare
+        Long accountId = 1L;
+
+        // logic
+        when(accountService.existsById(accountId)).thenReturn(false);
+
+        // test/check
+        this.mockMvc.perform(delete(Constants.ROUTE_ACCOUNT + Constants.ROUTE_ID, accountId))
+                .andExpect(status().isNotFound());
 
     }
 

--- a/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/AuthControllerTest.java
+++ b/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/AuthControllerTest.java
@@ -1,0 +1,113 @@
+package br.com.luizalabsserverrest.controller;
+
+import br.com.luizalabsserverrest.controller.request.AccountRequest;
+import br.com.luizalabsserverrest.security.JwtAuthenticationEntryPoint;
+import br.com.luizalabsserverrest.security.JwtTokenUtil;
+import br.com.luizalabsserverrest.service.JwtUserDetailsService;
+import br.com.luizalabsserverrest.util.Constants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zalando.problem.ProblemModule;
+import org.zalando.problem.violations.ConstraintViolationProblemModule;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtUserDetailsService jwtUserDetailsService;
+
+    @MockBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockBean
+    private JwtTokenUtil jwtTokenUtil;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+
+        objectMapper.registerModule(new ProblemModule());
+        objectMapper.registerModule(new ConstraintViolationProblemModule());
+
+    }
+
+    @Test
+    void shouldSignIn()
+    {
+
+        // prepare
+        AccountRequest accountRequest = new AccountRequest();
+        accountRequest.setPassword("teste");
+        accountRequest.setUsername("teste");
+        String token = "Bearer Jfdljfjdsqpiwekljdapfoidsajflkajdklfoiqujlq";
+
+
+        // logic
+        when(jwtTokenUtil.generateToken(null)).thenReturn(token);
+
+        // test/check
+        try {
+            this.mockMvc.perform(post(Constants.ROUTE_SIGN_IN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(accountRequest)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.token", is(token)));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    void shouldNotSignIn()
+    {
+
+        // prepare
+        AccountRequest accountRequest = new AccountRequest();
+        accountRequest.setPassword("teste");
+        accountRequest.setUsername("teste");
+        String token = "Bearer Jfdljfjdsqpiwekljdapfoidsajflkajdklfoiqujlq";
+
+
+        // logic
+        when(authenticationManager
+                .authenticate(new UsernamePasswordAuthenticationToken(accountRequest.getUsername()
+                        ,accountRequest.getPassword()))).thenThrow(BadCredentialsException.class);
+
+        // test/check
+        try {
+            this.mockMvc.perform(post(Constants.ROUTE_SIGN_IN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(accountRequest)))
+                    .andExpect(status().isBadRequest());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+}

--- a/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/ProductControllerTest.java
+++ b/luizalabs-server-rest/src/test/java/br/com/luizalabsserverrest/controller/ProductControllerTest.java
@@ -1,0 +1,254 @@
+package br.com.luizalabsserverrest.controller;
+
+import br.com.luizalabsserverrest.model.entity.ClientEntity;
+import br.com.luizalabsserverrest.model.entity.ProductEntity;
+import br.com.luizalabsserverrest.security.JwtAuthenticationEntryPoint;
+import br.com.luizalabsserverrest.security.JwtTokenUtil;
+import br.com.luizalabsserverrest.service.JwtUserDetailsService;
+import br.com.luizalabsserverrest.service.impl.ClientServiceImpl;
+import br.com.luizalabsserverrest.service.impl.ProductServiceImpl;
+import br.com.luizalabsserverrest.util.Constants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.support.PagedListHolder;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.*;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.zalando.problem.ProblemModule;
+import org.zalando.problem.violations.ConstraintViolationProblemModule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ProductController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProductServiceImpl service;
+
+    @MockBean
+    private ClientServiceImpl clientService;
+
+    @MockBean
+    private JwtUserDetailsService jwtUserDetailsService;
+
+    @MockBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockBean
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private List<ProductEntity> list;
+
+    @BeforeEach
+    public void setup() {
+        this.list = new ArrayList<>();
+        ProductEntity productEntity = new ProductEntity();
+        productEntity.setId(1L);
+        productEntity.setBrand("brand");
+        productEntity.setImage("https://image-example.com.br");
+        productEntity.setPrice(1000.2);
+        productEntity.setReviewScore(1000.1);
+        this.list.add(productEntity);
+
+        objectMapper.registerModule(new ProblemModule());
+        objectMapper.registerModule(new ConstraintViolationProblemModule());
+
+    }
+
+    @Test
+    void shouldFetchAllByPageWithData() throws Exception{
+
+        // prepare
+        int page = 1;
+        Page<ProductEntity> productEntityPage = new PageImpl<>(list);
+
+        // logic
+        when(service.findAll(any(Pageable.class))).thenReturn(productEntityPage);
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT)
+                .param("page", String.valueOf(page)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldReturn404WhenFindAllByPageWithDataResponseIsEmpty() throws Exception{
+
+        // prepare
+        int page = 1;
+        Page<ProductEntity> productEntityPage = new PageImpl<>(new ArrayList<>());
+
+        // logic
+        when(service.findAll(any(Pageable.class))).thenReturn(productEntityPage);
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT)
+                .param("page", String.valueOf(page)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn400WhenPageIsNegative() throws Exception{
+
+        // prepare
+        int page = -1;
+        Page<ProductEntity> productEntityPage = new PageImpl<>(new ArrayList<>());
+
+        // logic
+        when(service.findAll(any(Pageable.class))).thenReturn(productEntityPage);
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT)
+                .param("page", String.valueOf(page)))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    void shouldFetchById() throws Exception{
+
+        // prepare
+        Long productId = 1L;
+        ProductEntity productEntity = list.get(0);
+
+        // logic
+        when(service.findById(productId)).thenReturn(Optional.of(productEntity));
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT + Constants.ROUTE_ID, productId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.brand", is(productEntity.getBrand())))
+                .andExpect(jsonPath("$.image", is(productEntity.getImage())))
+                .andExpect(jsonPath("$.id", is(productEntity.getId().intValue())))
+                .andExpect(jsonPath("$.price", is(productEntity.getPrice())))
+                .andExpect(jsonPath("$.reviewScore", is(productEntity.getReviewScore())))
+                .andExpect(jsonPath("$.title", is(productEntity.getTitle())));
+    }
+
+    @Test
+    void shouldReturn404WhenFindProductById() throws Exception{
+
+        // prepare
+        Long productId = 1L;
+
+        // logic
+        when(service.findById(productId)).thenReturn(Optional.empty());
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT + Constants.ROUTE_ID, productId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldDeleteProduct() throws Exception{
+
+        // prepare
+        Long productId = 1L;
+
+        // logic
+        when(service.existsById(productId)).thenReturn(true);
+        doNothing().when(service).deleteById(productId);
+
+        // test/check
+        this.mockMvc.perform(delete(Constants.ROUTE_PRODUCT + Constants.ROUTE_ID, productId))
+                .andExpect(status().isNoContent());
+
+    }
+
+    @Test
+    void shouldReturn404WhenDeletingNonExistingProduct() throws Exception{
+
+        // prepare
+        Long productId = 1L;
+
+        // logic
+        when(service.existsById(productId)).thenReturn(false);
+
+        // test/check
+        this.mockMvc.perform(delete(Constants.ROUTE_PRODUCT + Constants.ROUTE_ID, productId))
+                .andExpect(status().isNotFound());
+
+    }
+
+    @Test
+    void shouldCreateNewProduct() throws Exception{
+
+        // prepare
+        ProductEntity productEntity = this.list.get(0);
+
+        // logic
+        when(service.save(any(ProductEntity.class))).thenReturn(productEntity);
+
+        // test/check
+        this.mockMvc.perform(post(Constants.ROUTE_PRODUCT + Constants.ROUTE_SAVE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(productEntity)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.brand", is(productEntity.getBrand())))
+                .andExpect(jsonPath("$.image", is(productEntity.getImage())))
+                .andExpect(jsonPath("$.price", is(productEntity.getPrice())))
+                .andExpect(jsonPath("$.reviewScore", is(productEntity.getReviewScore())))
+                .andExpect(jsonPath("$.title", is(productEntity.getTitle())));
+
+    }
+
+    @Test
+    void shouldReturnProductsListFromClient() throws Exception{
+
+        // prepare
+        Long clientId = 1L;
+        ClientEntity clientEntity = new ClientEntity();
+        clientEntity.setId(1L);
+        clientEntity.setEmail("teste@gmail.com");
+        clientEntity.setName("EnsleyEC");
+
+        // logic
+        when(clientService.findById(clientId)).thenReturn(Optional.of(clientEntity));
+        when(service.findAndFetchClientEntityListEagerly(clientId)).thenReturn(list);
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT + Constants.ROUTE_FIND_FAVORITE_PRODUCTS_BY_CLIENT,clientId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()", is(list.size())));
+
+    }
+
+    @Test
+    void shouldReturn404WhenFindingProductsListFromANonExistingClient() throws Exception{
+
+        // prepare
+        Long clientId = 1L;
+
+        // logic
+        when(clientService.findById(clientId)).thenReturn(Optional.empty());
+
+        // test/check
+        this.mockMvc.perform(get(Constants.ROUTE_PRODUCT + Constants.ROUTE_FIND_FAVORITE_PRODUCTS_BY_CLIENT,clientId))
+                .andExpect(status().isNotFound());
+
+    }
+
+
+}


### PR DESCRIPTION
- Foi feito alguns testes unitários para pegar casos bases da API,
       usando o conceio de 'mockar' as classes services.
            - Ao todo agora, são 27 testes unitários.
            - Pegando os endpoints das controllers Auth, Account, Product e
            Client.
- Versao do projeto foi atualizado para V0.0.5
- No README.md foi adicionado a informação dos testes unitários que estão
       sendo executados.